### PR TITLE
shanil create lattice route and output correct oxDNA format

### DIFF
--- a/origamiUROP/polygons.py
+++ b/origamiUROP/polygons.py
@@ -6,24 +6,12 @@ import meshio
 import matplotlib.pyplot as plt
 import matplotlib.tri as tri
 
-from .oxdna.strand import Strand, generate_helix
-from .oxdna import Nucleotide, System
-from .tools import DNAEdge, DNANode
+from origamiUROP.oxdna.strand import Strand, generate_helix
+from origamiUROP.oxdna import Nucleotide, System
+from origamiUROP.tools import DNAEdge, DNANode
+from origamiUROP.lattice._lattice import Lattice
+from origamiUROP.lattice import LatticeNode, LatticeRoute
 
-# class Vertex:
-#     """
-#     A Vertex is a point in space that is connected to other vertices
-
-#     Defined simply by: x, y and z (in 3D)
-#     """
-
-#     def __init__(self, position: np.ndarray):
-#         self.position = position
-#         self.x = position[:, 0]
-#         self.y = position[:, 1]
-
-#     def distance(self, another_vertex: "Vertex") -> float:
-#         return np.linalg.norm(self.position - another_vertex.position)
 
 EDGE_TYPE = {0: "boundary", 1: "scaffold", 2: "staple"}
 
@@ -35,7 +23,7 @@ class Edge(DNAEdge):
 
     def __init__(self, vertex_1: list, vertex_2: list, edge_kind: int = 0):
         super().__init__(vertex_1, vertex_2)
-        
+
         # don't use type because that's a protected function in Python
         self.kind = EDGE_TYPE[edge_kind]
 
@@ -150,6 +138,14 @@ class BoundaryPolygon:
             fig.savefig(fout)
         if show:
             fig.show()
+
+    def lattice(self, **kwargs):
+        """
+        Generate a Lattice object defining a large set of nucleotide sites
+        where the scaffold can be laid
+        """
+        _lattice = Lattice(self.vertices, **kwargs)
+        return _lattice
 
 
 # ---plot---#

--- a/protocols/lattice-route/DNA_Snake.py
+++ b/protocols/lattice-route/DNA_Snake.py
@@ -4,6 +4,10 @@ from origamiUROP.polygons import BoundaryPolygon
 
 import numpy as np
 
+from os import path
+
+ROOT = "/".join(path.abspath(__file__).split("/")[:-1])
+
 
 def generate(polygon_vertices: np.ndarray):
     polygon = BoundaryPolygon(polygon_vertices)
@@ -12,17 +16,16 @@ def generate(polygon_vertices: np.ndarray):
     nodes = lattice.route()
 
     route = LatticeRoute(nodes)
-
-    system = System(np.array([50.0, 50.0, 50.0]))
+    system = route.system()
     system.add_strand(route)
 
     route.plot()
-    system.write_oxDNA()
+    system.write_oxDNA(root=ROOT)
 
 
 def generate_square():
-    square = np.array([[0, 0, 0], [0.0, 1.0, 0.0], [1.0, 1.0, 0.0], [1.0, 0.0, 0.0]])
-    generate(square * 10)
+    square = np.array([[0, 0, 0], [10.0, 1.0, 0.0], [10.0, 1.0, 0.0], [1.0, 0.0, 0.0]])
+    generate(square)
 
 
 if __name__ == "__main__":

--- a/protocols/lattice-route/DNA_Snake.py
+++ b/protocols/lattice-route/DNA_Snake.py
@@ -1,0 +1,29 @@
+from origamiUROP.oxdna import System
+from origamiUROP.lattice import LatticeRoute
+from origamiUROP.polygons import BoundaryPolygon
+
+import numpy as np
+
+
+def generate(polygon_vertices: np.ndarray):
+    polygon = BoundaryPolygon(polygon_vertices)
+    lattice = polygon.lattice()
+
+    nodes = lattice.route()
+
+    route = LatticeRoute(nodes)
+
+    system = System(np.array([50.0, 50.0, 50.0]))
+    system.add_strand(route)
+
+    route.plot()
+    system.write_oxDNA()
+
+
+def generate_square():
+    square = np.array([[0, 0, 0], [0.0, 1.0, 0.0], [1.0, 1.0, 0.0], [1.0, 0.0, 0.0]])
+    generate(square * 10)
+
+
+if __name__ == "__main__":
+    generate_square()

--- a/test/test_routeprotocol.py
+++ b/test/test_routeprotocol.py
@@ -1,0 +1,21 @@
+from origamiUROP.oxdna import System
+from origamiUROP.lattice import LatticeRoute
+from origamiUROP.polygons import BoundaryPolygon
+
+import numpy as np
+
+
+def test_square():
+    square = np.array([[0, 0, 0], [0.0, 1.0, 0.0], [1.0, 1.0, 0.0], [1.0, 0.0, 0.0]])
+    polygon = BoundaryPolygon(square * 10)
+    lattice = polygon.lattice()
+    nodes = lattice.route()
+    route = LatticeRoute(nodes)
+    route.plot()
+    system = System(np.array([50.0, 50.0, 50.0]))
+    system.add_strand(route)
+    system.write_oxDNA()
+
+
+if __name__ == "__main__":
+    test_square()


### PR DESCRIPTION
## Update
@debeshmandal We can now generate a very simple route for a given square polygon.

## Issues
As in #35 we need to define our lattice so that we are creating the correct distance for lattice spacings in between lattice sites.
- `Lattice` units -> 1 unit = 1 basepair distance
- Need to convert this into the correct form before creating `LatticeNodes`

The route generated by the lattice is:
![image](https://user-images.githubusercontent.com/67636677/89413453-c1e29a00-d720-11ea-90d0-a76d5ba9f291.png)

When visualised in ovito:
![image](https://user-images.githubusercontent.com/67636677/89413678-230a6d80-d721-11ea-8857-a6c92d3b8804.png)

Closes #34 